### PR TITLE
DEPLOY: fix configure zip and dll deploy to installer

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -72,9 +72,11 @@
     </configurations>
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="e6f98a45-e32c-41de-8e42-448e5eea13bc" name="Changes" comment="refactor: update CMake configurations to include Python3 support and adjust environment variables for 32-bit and 64-bit builds">
+    <list default="true" id="e6f98a45-e32c-41de-8e42-448e5eea13bc" name="Changes" comment="feat: add README and README_RU files with project documentation and usage instructions">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/third_party/json/json.hpp" beforeDir="false" afterPath="$PROJECT_DIR$/third_party/json/json.hpp" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/CMakeLists.txt" beforeDir="false" afterPath="$PROJECT_DIR$/CMakeLists.txt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/installer_script.iss" beforeDir="false" afterPath="$PROJECT_DIR$/installer_script.iss" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/python_bridge/CMakeLists.txt" beforeDir="false" afterPath="$PROJECT_DIR$/python_bridge/CMakeLists.txt" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -141,32 +143,32 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "CMake Application.ExeLaunchHandler.executor": "Run",
-    "ModuleVcsDetector.initialDetectionPerformed": "true",
-    "RunOnceActivity.RadMigrateCodeStyle": "true",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "RunOnceActivity.cidr.known.project.marker": "true",
-    "RunOnceActivity.git.unshallow": "true",
-    "RunOnceActivity.readMode.enableVisualFormatting": "true",
-    "RunOnceActivity.west.config.association.type.startup.service": "true",
-    "SHARE_PROJECT_CONFIGURATION_FILES": "true",
-    "cf.first.check.clang-format": "false",
-    "cidr.known.project.marker": "true",
-    "git-widget-placeholder": "debug-msvc",
-    "ignore.virus.scanning.warn.message": "true",
-    "last_opened_file_path": "C:/Users/User/source/repos/open-source/ExeLaunchHandler/resources",
-    "node.js.detected.package.eslint": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "nodejs_package_manager_path": "npm",
-    "run.code.analysis.last.selected.profile": "pProject Default",
-    "settings.editor.selected.configurable": "CMakeSettings",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;CMake Application.ExeLaunchHandler.executor&quot;: &quot;Run&quot;,
+    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.RadMigrateCodeStyle&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.cidr.known.project.marker&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.readMode.enableVisualFormatting&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.west.config.association.type.startup.service&quot;: &quot;true&quot;,
+    &quot;SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
+    &quot;cf.first.check.clang-format&quot;: &quot;false&quot;,
+    &quot;cidr.known.project.marker&quot;: &quot;true&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;debug-msvc&quot;,
+    &quot;ignore.virus.scanning.warn.message&quot;: &quot;true&quot;,
+    &quot;last_opened_file_path&quot;: &quot;C:/Users/User/source/repos/open-source/ExeLaunchHandler/resources&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;run.code.analysis.last.selected.profile&quot;: &quot;pProject Default&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;CMakeSettings&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   }
-}]]></component>
+}</component>
   <component name="RecentsManager">
     <key name="CopyFile.RECENT_KEYS">
       <recent name="C:\Users\User\source\repos\open-source\ExeLaunchHandler\resources" />
@@ -260,7 +262,9 @@
       <workItem from="1754340755564" duration="196000" />
       <workItem from="1754340965899" duration="16000" />
       <workItem from="1754340996811" duration="1612000" />
-      <workItem from="1754412379658" duration="17961000" />
+      <workItem from="1754412379658" duration="18703000" />
+      <workItem from="1754434861076" duration="763000" />
+      <workItem from="1754460790104" duration="2091000" />
     </task>
     <task id="LOCAL-00001" summary="refactor: tidy up CMakeLists.txt formatting and include new pipes_tab sources">
       <option name="closed" value="true" />
@@ -486,7 +490,15 @@
       <option name="project" value="LOCAL" />
       <updated>1754432846407</updated>
     </task>
-    <option name="localTasksCounter" value="29" />
+    <task id="LOCAL-00029" summary="feat: add README and README_RU files with project documentation and usage instructions">
+      <option name="closed" value="true" />
+      <created>1754433883824</created>
+      <option name="number" value="00029" />
+      <option name="presentableId" value="LOCAL-00029" />
+      <option name="project" value="LOCAL" />
+      <updated>1754433883824</updated>
+    </task>
+    <option name="localTasksCounter" value="30" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -498,7 +510,6 @@
     <isAutomaticReloadCMake value="true" />
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="feat: add process priority handling to LoggerConfig and ExeRunnerConfig" />
     <MESSAGE value="refactor: update log level handling to use new namespace structure" />
     <MESSAGE value="refactor: change GetDescription return type from std::string_view to const std::string&amp;" />
     <MESSAGE value="feat: add process priority selection to ConfigTab and update logger level handling" />
@@ -523,6 +534,7 @@
     <MESSAGE value="{&#13;&#10;    &quot;error&quot;: {&#13;&#10;        &quot;message&quot;: &quot;You didn't provide an API key. You need to provide your API key in an Authorization header using Bearer auth (i.e. Authorization: Bearer YOUR_KEY), or as the password field (with blank username) if you're accessing the API from your browser and are prompted for a username and password. You can obtain an API key from https://platform.openai.com/account/api-keys.&quot;,&#13;&#10;        &quot;type&quot;: &quot;invalid_request_error&quot;,&#13;&#10;        &quot;param&quot;: null,&#13;&#10;        &quot;code&quot;: null&#13;&#10;    }&#13;&#10;}" />
     <MESSAGE value="feat: add installer script for ExeLaunchHandler with configuration for 32-bit and 64-bit builds" />
     <MESSAGE value="refactor: update CMake configurations to include Python3 support and adjust environment variables for 32-bit and 64-bit builds" />
-    <option name="LAST_COMMIT_MESSAGE" value="refactor: update CMake configurations to include Python3 support and adjust environment variables for 32-bit and 64-bit builds" />
+    <MESSAGE value="feat: add README and README_RU files with project documentation and usage instructions" />
+    <option name="LAST_COMMIT_MESSAGE" value="feat: add README and README_RU files with project documentation and usage instructions" />
   </component>
 </project>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,12 @@ add_custom_command(TARGET ExeLaunchHandler POST_BUILD
         COMMENT "Copying splash.png to resources directory"
 )
 
+configure_file(
+        "${Python3_ROOT_DIR}/python310.zip"
+        "${CMAKE_BINARY_DIR}/python310.zip"
+        COPYONLY
+)
+
 if(WINDEPLOYQT_EXECUTABLE)
     add_custom_command(TARGET ExeLaunchHandler POST_BUILD
         COMMAND "${WINDEPLOYQT_EXECUTABLE}" "$<TARGET_FILE:ExeLaunchHandler>"

--- a/installer_script.iss
+++ b/installer_script.iss
@@ -32,6 +32,8 @@ Source: "out\release-64\ExeLaunchHandler.PyPipeBridge.dll"; DestDir: "{app}"; Ch
 Source: "out\release-64\ExeLaunchHandler.ResultsAPI.dll"; DestDir: "{app}"; Check: Is64BitInstallMode
 Source: "out\release-64\ExeLaunchHandler.UI.dll"; DestDir: "{app}"; Check: Is64BitInstallMode
 Source: "out\release-64\pipebridge.cp310-win_amd64.pyd"; DestDir: "{app}"; Check: Is64BitInstallMode
+Source: "out\release-64\python310.dll"; DestDir: "{app}"; Check: Is64BitInstallMode
+Source: "out\release-64\python310.zip"; DestDir: "{app}"; Check: Is64BitInstallMode
 
 ; === DLL и PYD (32-bit) ===
 Source: "out\release-32\ExeLaunchHandler.Config.dll"; DestDir: "{app}"; Check: not Is64BitInstallMode
@@ -43,6 +45,9 @@ Source: "out\release-32\ExeLaunchHandler.PyPipeBridge.dll"; DestDir: "{app}"; Ch
 Source: "out\release-32\ExeLaunchHandler.ResultsAPI.dll"; DestDir: "{app}"; Check: not Is64BitInstallMode
 Source: "out\release-32\ExeLaunchHandler.UI.dll"; DestDir: "{app}"; Check: not Is64BitInstallMode
 Source: "out\release-32\pipebridge.cp310-win32.pyd"; DestDir: "{app}"; Check: not Is64BitInstallMode
+Source: "out\release-32\python310.dll"; DestDir: "{app}"; Check: not Is64BitInstallMode
+Source: "out\release-32\python310.zip"; DestDir: "{app}"; Check: not Is64BitInstallMode
+
 
 ; === Qt DLL (64-bit) ===
 Source: "out\release-64\Qt5Core.dll"; DestDir: "{app}"; Check: Is64BitInstallMode

--- a/python_bridge/CMakeLists.txt
+++ b/python_bridge/CMakeLists.txt
@@ -48,3 +48,9 @@ target_link_libraries(ExeLaunchHandler.PyPipeBridge
         ExeLaunchHandler.Logging
         ExeLaunchHandler.Pipes
 )
+
+add_custom_command(TARGET ExeLaunchHandler.PyPipeBridge POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        ${Python3_RUNTIME_LIBRARY}
+        $<TARGET_FILE_DIR:ExeLaunchHandler>
+)


### PR DESCRIPTION
This pull request primarily adds support for bundling the Python 3.10 runtime with the project, ensuring both the DLL and ZIP files are included in build outputs and installer packages for both 32-bit and 64-bit builds. Additionally, minor updates were made to project configuration and metadata files to reflect these changes.

**Python runtime integration and installer updates:**

* Updated `installer_script.iss` to include `python310.dll` and `python310.zip` for both 32-bit and 64-bit installation modes, ensuring the Python runtime is distributed with the application. [[1]](diffhunk://#diff-7a472a65c60ebebfbe7e87f4b53932b93486b383b95fad6637a096ad909558aaR35-R36) [[2]](diffhunk://#diff-7a472a65c60ebebfbe7e87f4b53932b93486b383b95fad6637a096ad909558aaR48-R50)
* Added a `configure_file` step in `CMakeLists.txt` to copy `python310.zip` from the Python installation directory to the build output.
* Updated `python_bridge/CMakeLists.txt` to copy the Python runtime DLL to the output directory after building the `ExeLaunchHandler.PyPipeBridge` target.

**Project configuration and metadata updates:**

* Changed the changelist and commit message in `.idea/workspace.xml` to reference the addition of README files and usage instructions, and incremented the local tasks counter. [[1]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cL75-R79) [[2]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cL489-R501) [[3]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cL526-R538)
* Minor formatting adjustments to the `.idea/workspace.xml` properties component for consistency.
* Updated work item logs in `.idea/workspace.xml` to reflect recent activity.